### PR TITLE
Password rehash fix for rhel_6/ruby 1.8.7 support (and 1.9.0+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,17 @@
-branches:
-  only:
-    - master
+---
 language: ruby
-before_install:
-  - gem update bundler
-  - bundle --version
-  - gem update --system 2.1.11
-  - gem --version
-bundler_args: --without development
-script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
-after_success:
-  - git clone -q git://github.com/puppetlabs/ghpublisher.git .forge-release
-  - .forge-release/publish
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 2.7.0"
-    - PUPPET_GEM_VERSION="~> 3.3.0"
-  global:
-    - PUBLISHER_LOGIN=puppetlabs
-    - secure: "iUYpjvk33JffZB9lVRqjuwRWesvcvmTknh908xnf60rUOA0QbGEPXxQY+LsQJEIimVsMA22fV6vp9BcqMEjO7OfK2MvAWsEWU/lG+kisFqhWDRf96sADE7k/RvPWJeB2xe+lWXK7Eh26jgctNfk4NptX1X1MjGmdzEvH7Aq79/w="
+bundler_args: --without system_tests
+script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 matrix:
-  exclude:
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
+  fast_finish: true
+  include:
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,30 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-group :test, :development do
-  gem 'rspec-puppet',            :require => false
+group :development, :unit_tests do
   gem 'rake',                    :require => false
+  gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
-  gem 'serverspec',              :require => false
   gem 'puppet-lint',             :require => false
-  gem 'pry',                     :require => false
   gem 'simplecov',               :require => false
-  gem 'beaker',                  :require => false
-  gem 'beaker-rspec',            :require => false
+  gem 'puppet_facts',            :require => false
+  gem 'json',                    :require => false
 end
 
-if puppetversion = ENV['PUPPET_VERSION']
+group :system_tests do
+  gem 'beaker-rspec',  :require => false
+  gem 'serverspec',    :require => false
+end
+
+if facterversion = ENV['FACTER_GEM_VERSION']
+  gem 'facter', facterversion, :require => false
+else
+  gem 'facter', :require => false
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion, :require => false
 else
   gem 'puppet', :require => false
 end
+
+# vim:ft=ruby

--- a/lib/puppet/feature/json.rb
+++ b/lib/puppet/feature/json.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:json, :libs => ["json"])

--- a/lib/puppet/feature/orderedhash.rb
+++ b/lib/puppet/feature/orderedhash.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:orderedhash, :libs => ["active_support/ordered_hash"])

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -57,6 +57,20 @@ class mongodb::server::config {
   if ($logpath and $syslog) { fail('You cannot use syslog with logpath')}
 
   if ($ensure == 'present' or $ensure == true) {
+    # Install external mongo provider dependencies for ruby < 1.9.0
+    if versioncmp($::rubyversion, '1.9.0') < 0 {
+      # Active support provides ordered hashes and Ruby 1.8.7 must use ver 3.1.0 
+      package { 'activesupport':
+        ensure    => '3.1.0',
+        provider  => 'gem',
+      }
+      package { 'json':
+        ensure    => 'installed',
+        provider  => 'gem',
+      }
+      Package['activesupport'] -> Package<| provider == 'mongodb' |>
+      Package['json'] -> Package<| provider == 'mongodb' |>
+    }
 
     # Exists for future compatibility and clarity.
     if $auth {

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -1,5 +1,8 @@
 require 'spec_helper'
 require 'json'
+if RUBY_VERSION < '1.9.0'
+  require 'active_support/ordered_hash'
+else
 
 describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
@@ -39,15 +42,18 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'create' do
     it 'creates a user' do
-      user = {
-        :user => 'new_user',
-        :pwd => 'pass',
-        :customData => { :createdBy => "Puppet Mongodb_user['new_user']" },
-        :roles => ['role1','role2'],
-      }
+      if RUBY_VERSION < '1.9.0'
+        cmd = ActiveSupport::OrderedHash.new
+      else
+        cmd = Hash.new
+      end
+      cmd[:user] = 'new_user'
+      cmd[:pwd] = 'pass'
+      cmd[:customData] = { :createdBy => "Puppet Mongodb_user['new_user']" }
+      cmd[:roles] = ['role1','role2']
+      cmd[:digestPassword] = false
 
-
-      provider.expects(:mongo_eval).with("db.createUser(#{user.to_json})", 'new_database')
+      provider.expects(:mongo_eval).with("db.runCommand(#{cmd.to_json})", 'new_database')
       provider.create
     end
   end
@@ -73,11 +79,14 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'password_hash=' do
     it 'changes a password_hash' do
-      cmd = {
-          :updateUser => 'new_user',
-          :pwd => 'pass',
-          :digestPassword => false
-      }
+      if RUBY_VERSION < '1.9.0'
+        cmd = ActiveSupport::OrderedHash.new
+      else
+        cmd = Hash.new
+      end
+      cmd[:updateUser] = 'new_user'
+      cmd[:pwd] = 'pass'
+      cmd[:digestPassword] = false
       provider.expects(:mongo_eval).
         with("db.runCommand(#{cmd.to_json})", 'new_database')
       provider.password_hash=("newpass")

--- a/tests/replicaset.pp
+++ b/tests/replicaset.pp
@@ -7,9 +7,6 @@ node default {
     bind_ip    => ['0.0.0.0'],
     replset    => 'rsmain'
   }
-}
-
-node /mongo1/ inherits default {
   mongodb_replset{'rsmain':
     members => ['mongo1:27017', 'mongo2:27017', 'mongo3:27017']
   }


### PR DESCRIPTION
This PR fixes the password_rehash issue referenced in puppetlabs#150

In addition, it ensures that this works on rhel_6/ruby 1.8.7 installations as well as newer ones. Since it depends on the
support of an external gems, it ensures that they are installed in an idempotent manner and that the providers become
suitable only after the requirements are installed (if necessary).